### PR TITLE
Auto resize image to adjustImageBounds in AddTextFragment

### DIFF
--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/layout/ZoomLayout.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/layout/ZoomLayout.java
@@ -115,6 +115,12 @@ public class ZoomLayout extends FrameLayout implements ScaleGestureDetector.OnSc
         });
     }
 
+    public void setChildScale(float scaleFactor) {
+        scale = scaleFactor;
+        child().setScaleX(scaleFactor);
+        child().setScaleY(scaleFactor);
+    }
+
     @Override
     public boolean onScaleBegin(ScaleGestureDetector scaleDetector) {
         return true;

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -24,14 +24,12 @@
 
         <!--选择相册图片Activity-->
         <activity
-            android:name="iamutkarshtiwari.github.io.ananas.picchooser.SelectPictureActivity"
-            android:screenOrientation="portrait">
+            android:name="iamutkarshtiwari.github.io.ananas.picchooser.SelectPictureActivity">
         </activity>
 
         <!--图片编辑Activity-->
         <activity
             android:name="iamutkarshtiwari.github.io.ananas.editimage.EditImageActivity"
-            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustPan">
         </activity>
 


### PR DESCRIPTION
## Summary

Auto resize image to adjustImageBounds in AddTextFragment

## Detail

Added calculations to automatically scale the image (regardless of the image resolution) to fit the bounds within the screen without needing the user to scale it manually.

## Check List

- [ ] New API introduced?
- [ ] Spec changed?
- [x] Bug fix?
- [ ] Feature?
- [ ] Refactor?
- [ ] Version Update?

## ScreenShot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6258810/65584136-63ef0d00-dfbb-11e9-9166-d3e1b50d61f0.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/6258810/65584135-63ef0d00-dfbb-11e9-846a-a1a2a2dd49f8.gif" width="300" />

