### PR TITLE
Add support for source image Uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can receive the new processed image path and it's edit status like this-
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == PHOTO_EDITOR_REQUEST_CODE) { // same code you used while starting
-            String newFilePath = data.getStringExtra(EditImageActivity.OUTPUT_PATH);
+            String newFilePath = data.getStringExtra(ImageEditorIntentBuilder.OUTPUT_PATH);
             boolean isImageEdit = data.getBooleanExtra(EditImageActivity.IMAGE_IS_EDIT, false);
         }
     }

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -80,6 +80,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
             Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
+    public Uri sourceUri;
     public String sourceFilePath;
     public String outputFilePath;
     public String editorTitle;
@@ -115,7 +116,6 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
     private RedoUndoController redoUndoController;
     private OnMainBitmapChangeListener onMainBitmapChangeListener;
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
-    private Uri sourceUri;
 
     public static void start(Activity activity, Intent intent, int requestCode) {
         String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -118,7 +118,10 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
     private Uri sourceUri;
 
     public static void start(Activity activity, Intent intent, int requestCode) {
-        if (TextUtils.isEmpty(intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH))) {
+        String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
+        Uri sourceUri = (Uri) intent.getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+
+        if (TextUtils.isEmpty(sourcePath) && sourceUri == null) {
             Toast.makeText(activity, R.string.iamutkarshtiwari_github_io_ananas_not_selected, Toast.LENGTH_SHORT).show();
             return;
         }

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -119,9 +119,9 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
 
     public static void start(Activity activity, Intent intent, int requestCode) {
         String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
-        Uri sourceUri = (Uri) intent.getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        String sourceUriStr = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_URI);
 
-        if (TextUtils.isEmpty(sourcePath) && sourceUri == null) {
+        if (TextUtils.isEmpty(sourcePath) && TextUtils.isEmpty(sourceUriStr)) {
             Toast.makeText(activity, R.string.iamutkarshtiwari_github_io_ananas_not_selected, Toast.LENGTH_SHORT).show();
             return;
         }
@@ -156,7 +156,11 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
         isPortraitForced = getIntent().getBooleanExtra(ImageEditorIntentBuilder.FORCE_PORTRAIT, false);
         isSupportActionBarEnabled  = getIntent().getBooleanExtra(ImageEditorIntentBuilder.SUPPORT_ACTION_BAR_VISIBILITY, false);
 
-        sourceUri = (Uri) getIntent().getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        String sourceUriStr = getIntent().getStringExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        if (!TextUtils.isEmpty(sourceUriStr)) {
+            sourceUri = Uri.parse(sourceUriStr);
+        }
+
         sourceFilePath = getIntent().getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
         outputFilePath = getIntent().getStringExtra(ImageEditorIntentBuilder.OUTPUT_PATH);
         editorTitle = getIntent().getStringExtra(ImageEditorIntentBuilder.EDITOR_TITLE);
@@ -234,7 +238,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
             ActivityCompat.requestPermissions(this, requiredPermissions, PERMISSIONS_REQUEST_CODE);
         }
 
-        if (sourceFilePath != null && sourceFilePath.trim().length() > 0) {
+        if (!TextUtils.isEmpty(sourceFilePath)) {
             loadImageFromFile(sourceFilePath);
         } else {
             loadImageFromUri(sourceUri);
@@ -347,6 +351,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
 
     protected void onSaveTaskDone() {
         Intent returnIntent = new Intent();
+        returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_URI, sourceUri.toString());
         returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_PATH, sourceFilePath);
         returnIntent.putExtra(ImageEditorIntentBuilder.OUTPUT_PATH, outputFilePath);
         returnIntent.putExtra(IS_IMAGE_EDITED, numberOfOperations > 0);

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -14,7 +14,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
 ) {
     private var sourceUri: Uri? = null
 
-    constructor(context: Context,
+    @JvmOverloads constructor(context: Context,
                 sourceUri: Uri,
                 outputPath: String?,
                 intent: Intent = Intent(
@@ -75,6 +75,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
     }
 
     fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
+        this.sourceUri = sourceUri
         intent.putExtra(SOURCE_URI, sourceUri)
         intent.removeExtra(SOURCE_PATH)
         return this

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -76,7 +76,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
 
     fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
         this.sourceUri = sourceUri
-        intent.putExtra(SOURCE_URI, sourceUri)
+        intent.putExtra(SOURCE_URI, sourceUri.toString())
         intent.removeExtra(SOURCE_PATH)
         return this
     }
@@ -112,7 +112,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         } else if (!sourcePath.isNullOrBlank()) {
             intent.putExtra(SOURCE_PATH, sourcePath)
         } else {
-            intent.putExtra(SOURCE_URI, sourceUri)
+            intent.putExtra(SOURCE_URI, sourceUri.toString())
         }
 
         if (outputPath.isNullOrBlank()) {

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -2,6 +2,7 @@ package iamutkarshtiwari.github.io.ananas.editimage
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 
 class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Context,
                                                          private val sourcePath: String?,
@@ -11,6 +12,17 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
                                                                  EditImageActivity::class.java
                                                          )
 ) {
+    private var sourceUri: Uri? = null
+
+    constructor(context: Context,
+                sourceUri: Uri,
+                outputPath: String?,
+                intent: Intent = Intent(
+                        context,
+                        EditImageActivity::class.java
+                )) : this(context, null, outputPath, intent) {
+        this.sourceUri = sourceUri
+    }
 
     fun withAddText(): ImageEditorIntentBuilder {
         intent.putExtra(ADD_TEXT_FEATURE, true)
@@ -62,8 +74,15 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         return this
     }
 
+    fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
+        intent.putExtra(SOURCE_URI, sourceUri)
+        intent.removeExtra(SOURCE_PATH)
+        return this
+    }
+
     fun withSourcePath(sourcePath: String): ImageEditorIntentBuilder {
         intent.putExtra(SOURCE_PATH, sourcePath)
+        intent.removeExtra(SOURCE_URI)
         return this
     }
 
@@ -85,10 +104,14 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
     @Throws(Exception::class)
     fun build(): Intent {
 
-        if (sourcePath.isNullOrBlank()) {
-            throw Exception("Output image path required. Use withOutputPath(path) to provide the output image path.")
-        } else {
+        if (sourcePath.isNullOrBlank() && sourceUri == null) {
+            throw Exception("Source image required. Use withSourcePath(path) or withSourceUri(uri) to provide the source.")
+        } else if (!sourcePath.isNullOrBlank() && sourceUri != null) {
+            throw Exception("Multiple source images specified. Use either withSourcePath(path) or withSourceUri(uri) to provide the source.")
+        } else if (!sourcePath.isNullOrBlank()) {
             intent.putExtra(SOURCE_PATH, sourcePath)
+        } else {
+            intent.putExtra(SOURCE_URI, sourceUri)
         }
 
         if (outputPath.isNullOrBlank()) {
@@ -111,6 +134,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         const val BEAUTY_FEATURE = "beauty_feature"
         const val STICKER_FEATURE = "sticker_feature"
 
+        const val SOURCE_URI = "source_uri"
         const val SOURCE_PATH = "source_path"
         const val OUTPUT_PATH = "output_path"
         const val FORCE_PORTRAIT = "force_portrait"


### PR DESCRIPTION
This library looks great. Thanks for putting it together and sharing it.

I'm currently using ArthurHub/Android-Image-Cropper and want to switch over to Ananas. However, my app allows users to select an image from the gallery and passes the Uri to Cropper. An example Uri is:

content://com.android.providers.downloads.documents/document/4674

I spent some time trying to get a filepath from a Uri but various stackoverflow posts like this one convinced me its a bit of a mess and its easier to get a bitmap from a Uri than a filepath.

https://stackoverflow.com/questions/3401579/get-filename-and-path-from-uri-from-mediastore

This pull request reuses the code from ArthurHub/Android-Image-Cropper to get the source image from a uri
