### PR TITLE
Move undo and redo buttons to toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can receive the new processed image path and it's edit status like this-
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == PHOTO_EDITOR_REQUEST_CODE) { // same code you used while starting
-            String newFilePath = data.getStringExtra(EditImageActivity.OUTPUT_PATH);
+            String newFilePath = data.getStringExtra(ImageEditorIntentBuilder.OUTPUT_PATH);
             boolean isImageEdit = data.getBooleanExtra(EditImageActivity.IMAGE_IS_EDIT, false);
         }
     }

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -351,7 +351,11 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
 
     protected void onSaveTaskDone() {
         Intent returnIntent = new Intent();
-        returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_URI, sourceUri.toString());
+
+        if (sourceUri != null) {
+            returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_URI, sourceUri.toString());
+        }
+
         returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_PATH, sourceFilePath);
         returnIntent.putExtra(ImageEditorIntentBuilder.OUTPUT_PATH, outputFilePath);
         returnIntent.putExtra(IS_IMAGE_EDITED, numberOfOperations > 0);

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -80,6 +80,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
             Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
+    public Uri sourceUri;
     public String sourceFilePath;
     public String outputFilePath;
     public String editorTitle;
@@ -115,7 +116,6 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
     private RedoUndoController redoUndoController;
     private OnMainBitmapChangeListener onMainBitmapChangeListener;
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
-    private Uri sourceUri;
 
     public static void start(Activity activity, Intent intent, int requestCode) {
         String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -118,7 +118,10 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
     private Uri sourceUri;
 
     public static void start(Activity activity, Intent intent, int requestCode) {
-        if (TextUtils.isEmpty(intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH))) {
+        String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
+        Uri sourceUri = (Uri) intent.getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+
+        if (TextUtils.isEmpty(sourcePath) && sourceUri == null) {
             Toast.makeText(activity, R.string.iamutkarshtiwari_github_io_ananas_not_selected, Toast.LENGTH_SHORT).show();
             return;
         }

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -119,9 +119,9 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
 
     public static void start(Activity activity, Intent intent, int requestCode) {
         String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
-        Uri sourceUri = (Uri) intent.getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        String sourceUriStr = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_URI);
 
-        if (TextUtils.isEmpty(sourcePath) && sourceUri == null) {
+        if (TextUtils.isEmpty(sourcePath) && TextUtils.isEmpty(sourceUriStr)) {
             Toast.makeText(activity, R.string.iamutkarshtiwari_github_io_ananas_not_selected, Toast.LENGTH_SHORT).show();
             return;
         }
@@ -156,7 +156,11 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
         isPortraitForced = getIntent().getBooleanExtra(ImageEditorIntentBuilder.FORCE_PORTRAIT, false);
         isSupportActionBarEnabled  = getIntent().getBooleanExtra(ImageEditorIntentBuilder.SUPPORT_ACTION_BAR_VISIBILITY, false);
 
-        sourceUri = (Uri) getIntent().getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        String sourceUriStr = getIntent().getStringExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        if (!TextUtils.isEmpty(sourceUriStr)) {
+            sourceUri = Uri.parse(sourceUriStr);
+        }
+
         sourceFilePath = getIntent().getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
         outputFilePath = getIntent().getStringExtra(ImageEditorIntentBuilder.OUTPUT_PATH);
         editorTitle = getIntent().getStringExtra(ImageEditorIntentBuilder.EDITOR_TITLE);
@@ -234,7 +238,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
             ActivityCompat.requestPermissions(this, requiredPermissions, PERMISSIONS_REQUEST_CODE);
         }
 
-        if (sourceFilePath != null && sourceFilePath.trim().length() > 0) {
+        if (!TextUtils.isEmpty(sourceFilePath)) {
             loadImageFromFile(sourceFilePath);
         } else {
             loadImageFromUri(sourceUri);
@@ -347,6 +351,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
 
     protected void onSaveTaskDone() {
         Intent returnIntent = new Intent();
+        returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_URI, sourceUri.toString());
         returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_PATH, sourceFilePath);
         returnIntent.putExtra(ImageEditorIntentBuilder.OUTPUT_PATH, outputFilePath);
         returnIntent.putExtra(IS_IMAGE_EDITED, numberOfOperations > 0);

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -14,7 +14,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
 ) {
     private var sourceUri: Uri? = null
 
-    constructor(context: Context,
+    @JvmOverloads constructor(context: Context,
                 sourceUri: Uri,
                 outputPath: String?,
                 intent: Intent = Intent(
@@ -75,6 +75,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
     }
 
     fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
+        this.sourceUri = sourceUri
         intent.putExtra(SOURCE_URI, sourceUri)
         intent.removeExtra(SOURCE_PATH)
         return this

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -76,7 +76,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
 
     fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
         this.sourceUri = sourceUri
-        intent.putExtra(SOURCE_URI, sourceUri)
+        intent.putExtra(SOURCE_URI, sourceUri.toString())
         intent.removeExtra(SOURCE_PATH)
         return this
     }
@@ -112,7 +112,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         } else if (!sourcePath.isNullOrBlank()) {
             intent.putExtra(SOURCE_PATH, sourcePath)
         } else {
-            intent.putExtra(SOURCE_URI, sourceUri)
+            intent.putExtra(SOURCE_URI, sourceUri.toString())
         }
 
         if (outputPath.isNullOrBlank()) {

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -2,6 +2,7 @@ package iamutkarshtiwari.github.io.ananas.editimage
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 
 class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Context,
                                                          private val sourcePath: String?,
@@ -11,6 +12,17 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
                                                                  EditImageActivity::class.java
                                                          )
 ) {
+    private var sourceUri: Uri? = null
+
+    constructor(context: Context,
+                sourceUri: Uri,
+                outputPath: String?,
+                intent: Intent = Intent(
+                        context,
+                        EditImageActivity::class.java
+                )) : this(context, null, outputPath, intent) {
+        this.sourceUri = sourceUri
+    }
 
     fun withAddText(): ImageEditorIntentBuilder {
         intent.putExtra(ADD_TEXT_FEATURE, true)
@@ -62,8 +74,15 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         return this
     }
 
+    fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
+        intent.putExtra(SOURCE_URI, sourceUri)
+        intent.removeExtra(SOURCE_PATH)
+        return this
+    }
+
     fun withSourcePath(sourcePath: String): ImageEditorIntentBuilder {
         intent.putExtra(SOURCE_PATH, sourcePath)
+        intent.removeExtra(SOURCE_URI)
         return this
     }
 
@@ -85,10 +104,14 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
     @Throws(Exception::class)
     fun build(): Intent {
 
-        if (sourcePath.isNullOrBlank()) {
-            throw Exception("Output image path required. Use withOutputPath(path) to provide the output image path.")
-        } else {
+        if (sourcePath.isNullOrBlank() && sourceUri == null) {
+            throw Exception("Source image required. Use withSourcePath(path) or withSourceUri(uri) to provide the source.")
+        } else if (!sourcePath.isNullOrBlank() && sourceUri != null) {
+            throw Exception("Multiple source images specified. Use either withSourcePath(path) or withSourceUri(uri) to provide the source.")
+        } else if (!sourcePath.isNullOrBlank()) {
             intent.putExtra(SOURCE_PATH, sourcePath)
+        } else {
+            intent.putExtra(SOURCE_URI, sourceUri)
         }
 
         if (outputPath.isNullOrBlank()) {
@@ -111,6 +134,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         const val BEAUTY_FEATURE = "beauty_feature"
         const val STICKER_FEATURE = "sticker_feature"
 
+        const val SOURCE_URI = "source_uri"
         const val SOURCE_PATH = "source_path"
         const val OUTPUT_PATH = "output_path"
         const val FORCE_PORTRAIT = "force_portrait"

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/widget/RedoUndoController.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/widget/RedoUndoController.java
@@ -86,8 +86,8 @@ public class RedoUndoController implements View.OnClickListener {
     public void updateBtns() {
         //System.out.println("缓存Size = " + mEditCache.getSize() + "  current = " + mEditCache.getCur());
         //System.out.println("content = " + mEditCache.debugLog());
-        mUndoBtn.setVisibility(mEditCache.checkNextBitExist() ? View.VISIBLE : View.INVISIBLE);
-        mRedoBtn.setVisibility(mEditCache.checkPreBitExist() ? View.VISIBLE : View.INVISIBLE);
+        mUndoBtn.setVisibility(mEditCache.checkNextBitExist() ? View.VISIBLE : View.GONE);
+        mRedoBtn.setVisibility(mEditCache.checkPreBitExist() ? View.VISIBLE : View.GONE);
     }
 
     public void onDestroy() {

--- a/ananas/src/main/res/drawable/ic_redo_24.xml
+++ b/ananas/src/main/res/drawable/ic_redo_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFF" android:pathData="M18.4,10.6C16.55,8.99 14.15,8 11.5,8c-4.65,0 -8.58,3.03 -9.96,7.22L3.9,16c1.05,-3.19 4.05,-5.5 7.6,-5.5 1.95,0 3.73,0.72 5.12,1.88L13,16h9V7l-3.6,3.6z"/>
+</vector>

--- a/ananas/src/main/res/drawable/ic_redo_black_24dp.xml
+++ b/ananas/src/main/res/drawable/ic_redo_black_24dp.xml
@@ -1,8 +1,0 @@
-<vector android:height="24dp"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path
-        android:strokeColor="#000000" android:strokeWidth="1"
-        android:fillColor="#ffffff"
-        android:pathData="M18.4,10.6C16.55,8.99 14.15,8 11.5,8c-4.65,0 -8.58,3.03 -9.96,7.22L3.9,16c1.05,-3.19 4.05,-5.5 7.6,-5.5 1.95,0 3.73,0.72 5.12,1.88L13,16h9V7l-3.6,3.6z"/>
-</vector>

--- a/ananas/src/main/res/drawable/ic_undo_24.xml
+++ b/ananas/src/main/res/drawable/ic_undo_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFF" android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z"/>
+</vector>

--- a/ananas/src/main/res/drawable/ic_undo_black_24dp.xml
+++ b/ananas/src/main/res/drawable/ic_undo_black_24dp.xml
@@ -1,9 +1,0 @@
-<vector android:height="24dp"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path
-        android:strokeColor="#000000" android:strokeWidth="1"
-        android:fillColor="#ffffff"
-
-        android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z"/>
-</vector>

--- a/ananas/src/main/res/layout/activity_image_edit.xml
+++ b/ananas/src/main/res/layout/activity_image_edit.xml
@@ -15,20 +15,43 @@
             android:layout_width="wrap_content"
             android:layout_height="55dp"
             android:layout_gravity="left|center_vertical"
-            android:layout_margin="10dp"
-            android:layout_marginLeft="8dp"
+            android:paddingHorizontal="8dp"
             android:src="@drawable/back_arrow" />
 
         <TextView
             android:id="@+id/title"
             android:layout_width="wrap_content"
             android:layout_height="fill_parent"
-            android:layout_marginLeft="16dp"
+            android:layout_marginHorizontal="8dp"
             android:layout_toRightOf="@id/back_btn"
-            android:gravity="center"
+            android:layout_toLeftOf="@id/redo_undo_panel"
+            android:gravity="center_vertical"
             android:text="@string/iamutkarshtiwari_github_io_ananas_library_name"
             android:textColor="#ffffff"
             android:textSize="20sp" />
+
+        <LinearLayout
+            android:id="@+id/redo_undo_panel"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_toLeftOf="@id/banner_flipper"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/undo_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:paddingHorizontal="8dp"
+                android:gravity="center_vertical"
+                android:src="@drawable/ic_undo_24" />
+
+            <ImageView
+                android:id="@+id/redo_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:paddingHorizontal="8dp"
+                android:src="@drawable/ic_redo_24" />
+        </LinearLayout>
 
         <ViewFlipper
             android:id="@+id/banner_flipper"
@@ -36,7 +59,6 @@
             android:layout_height="fill_parent"
             android:layout_alignParentRight="true"
             android:layout_gravity="right"
-            android:layout_marginRight="8dp"
             android:flipInterval="1000"
             android:gravity="center">
 
@@ -44,6 +66,7 @@
                 android:id="@+id/save_btn"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:paddingHorizontal="8dp"
                 android:gravity="center"
                 android:text="@string/iamutkarshtiwari_github_io_ananas_done"
                 android:textAllCaps="true"
@@ -54,6 +77,7 @@
                 android:id="@+id/apply"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
+                android:paddingHorizontal="8dp"
                 android:gravity="center"
                 android:text="@string/iamutkarshtiwari_github_io_ananas_apply"
                 android:textAllCaps="true"
@@ -140,30 +164,4 @@
             android:layout_gravity="center"
             android:visibility="gone" />
     </FrameLayout>
-
-    <LinearLayout
-        android:id="@+id/redo_undo_panel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_above="@id/bottom_gallery"
-        android:layout_alignParentRight="true"
-        android:orientation="horizontal"
-        android:paddingBottom="16dp"
-        android:paddingLeft="8dp"
-        android:paddingRight="10dp">
-
-        <ImageView
-            android:id="@+id/undo_btn"
-            android:layout_width="40dp"
-            android:layout_height="35dp"
-            android:layout_marginRight="5dp"
-            android:src="@drawable/ic_undo_black_24dp" />
-
-        <ImageView
-            android:id="@+id/redo_btn"
-            android:layout_width="40dp"
-            android:layout_height="35dp"
-            android:src="@drawable/ic_redo_black_24dp" />
-    </LinearLayout>
-
 </RelativeLayout>


### PR DESCRIPTION
I've had feedback that the undo and redo buttons are a bit confusing. Some people thought part of the drawables had be cut off. Also when an image is a particular aspect ratio, the buttons appear on top of the image. In a busy image, these buttons aren't easy to see. Therefore I propose moving them up to the toolbar, next to the Done/Apply button