### PR TITLE
Return canceled on back

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can receive the new processed image path and it's edit status like this-
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == PHOTO_EDITOR_REQUEST_CODE) { // same code you used while starting
-            String newFilePath = data.getStringExtra(EditImageActivity.OUTPUT_PATH);
+            String newFilePath = data.getStringExtra(ImageEditorIntentBuilder.OUTPUT_PATH);
             boolean isImageEdit = data.getBooleanExtra(EditImageActivity.IMAGE_IS_EDIT, false);
         }
     }

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -351,7 +351,11 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
 
     protected void onSaveTaskDone() {
         Intent returnIntent = new Intent();
-        returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_URI, sourceUri.toString());
+
+        if (sourceUri != null) {
+            returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_URI, sourceUri.toString());
+        }
+
         returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_PATH, sourceFilePath);
         returnIntent.putExtra(ImageEditorIntentBuilder.OUTPUT_PATH, outputFilePath);
         returnIntent.putExtra(IS_IMAGE_EDITED, numberOfOperations > 0);

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -257,6 +257,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
                 // If request is cancelled, the result arrays are empty.
                 if (!(grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED)) {
+                    setResult(RESULT_CANCELED);
                     finish();
                 }
                 break;
@@ -321,7 +322,12 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
                 } else {
                     AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
                     alertDialogBuilder.setMessage(R.string.iamutkarshtiwari_github_io_ananas_exit_without_save)
-                            .setCancelable(false).setPositiveButton(R.string.iamutkarshtiwari_github_io_ananas_confirm, (dialog, id) -> finish()).setNegativeButton(R.string.iamutkarshtiwari_github_io_ananas_cancel, (dialog, id) -> dialog.cancel());
+                            .setCancelable(false)
+                            .setPositiveButton(R.string.iamutkarshtiwari_github_io_ananas_confirm, (dialog, id) -> {
+                                setResult(RESULT_CANCELED);
+                                finish();
+                            })
+                            .setNegativeButton(R.string.iamutkarshtiwari_github_io_ananas_cancel, (dialog, id) -> dialog.cancel());
 
                     AlertDialog alertDialog = alertDialogBuilder.create();
                     alertDialog.show();

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -80,6 +80,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
             Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
+    public Uri sourceUri;
     public String sourceFilePath;
     public String outputFilePath;
     public String editorTitle;
@@ -115,7 +116,6 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
     private RedoUndoController redoUndoController;
     private OnMainBitmapChangeListener onMainBitmapChangeListener;
     private CompositeDisposable compositeDisposable = new CompositeDisposable();
-    private Uri sourceUri;
 
     public static void start(Activity activity, Intent intent, int requestCode) {
         String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -118,7 +118,10 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
     private Uri sourceUri;
 
     public static void start(Activity activity, Intent intent, int requestCode) {
-        if (TextUtils.isEmpty(intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH))) {
+        String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
+        Uri sourceUri = (Uri) intent.getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+
+        if (TextUtils.isEmpty(sourcePath) && sourceUri == null) {
             Toast.makeText(activity, R.string.iamutkarshtiwari_github_io_ananas_not_selected, Toast.LENGTH_SHORT).show();
             return;
         }

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -119,9 +119,9 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
 
     public static void start(Activity activity, Intent intent, int requestCode) {
         String sourcePath = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
-        Uri sourceUri = (Uri) intent.getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        String sourceUriStr = intent.getStringExtra(ImageEditorIntentBuilder.SOURCE_URI);
 
-        if (TextUtils.isEmpty(sourcePath) && sourceUri == null) {
+        if (TextUtils.isEmpty(sourcePath) && TextUtils.isEmpty(sourceUriStr)) {
             Toast.makeText(activity, R.string.iamutkarshtiwari_github_io_ananas_not_selected, Toast.LENGTH_SHORT).show();
             return;
         }
@@ -156,7 +156,11 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
         isPortraitForced = getIntent().getBooleanExtra(ImageEditorIntentBuilder.FORCE_PORTRAIT, false);
         isSupportActionBarEnabled  = getIntent().getBooleanExtra(ImageEditorIntentBuilder.SUPPORT_ACTION_BAR_VISIBILITY, false);
 
-        sourceUri = (Uri) getIntent().getSerializableExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        String sourceUriStr = getIntent().getStringExtra(ImageEditorIntentBuilder.SOURCE_URI);
+        if (!TextUtils.isEmpty(sourceUriStr)) {
+            sourceUri = Uri.parse(sourceUriStr);
+        }
+
         sourceFilePath = getIntent().getStringExtra(ImageEditorIntentBuilder.SOURCE_PATH);
         outputFilePath = getIntent().getStringExtra(ImageEditorIntentBuilder.OUTPUT_PATH);
         editorTitle = getIntent().getStringExtra(ImageEditorIntentBuilder.EDITOR_TITLE);
@@ -234,7 +238,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
             ActivityCompat.requestPermissions(this, requiredPermissions, PERMISSIONS_REQUEST_CODE);
         }
 
-        if (sourceFilePath != null && sourceFilePath.trim().length() > 0) {
+        if (!TextUtils.isEmpty(sourceFilePath)) {
             loadImageFromFile(sourceFilePath);
         } else {
             loadImageFromUri(sourceUri);
@@ -347,6 +351,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
 
     protected void onSaveTaskDone() {
         Intent returnIntent = new Intent();
+        returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_URI, sourceUri.toString());
         returnIntent.putExtra(ImageEditorIntentBuilder.SOURCE_PATH, sourceFilePath);
         returnIntent.putExtra(ImageEditorIntentBuilder.OUTPUT_PATH, outputFilePath);
         returnIntent.putExtra(IS_IMAGE_EDITED, numberOfOperations > 0);

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -14,7 +14,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
 ) {
     private var sourceUri: Uri? = null
 
-    constructor(context: Context,
+    @JvmOverloads constructor(context: Context,
                 sourceUri: Uri,
                 outputPath: String?,
                 intent: Intent = Intent(
@@ -75,6 +75,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
     }
 
     fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
+        this.sourceUri = sourceUri
         intent.putExtra(SOURCE_URI, sourceUri)
         intent.removeExtra(SOURCE_PATH)
         return this

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -76,7 +76,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
 
     fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
         this.sourceUri = sourceUri
-        intent.putExtra(SOURCE_URI, sourceUri)
+        intent.putExtra(SOURCE_URI, sourceUri.toString())
         intent.removeExtra(SOURCE_PATH)
         return this
     }
@@ -112,7 +112,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         } else if (!sourcePath.isNullOrBlank()) {
             intent.putExtra(SOURCE_PATH, sourcePath)
         } else {
-            intent.putExtra(SOURCE_URI, sourceUri)
+            intent.putExtra(SOURCE_URI, sourceUri.toString())
         }
 
         if (outputPath.isNullOrBlank()) {

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/ImageEditorIntentBuilder.kt
@@ -2,6 +2,7 @@ package iamutkarshtiwari.github.io.ananas.editimage
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 
 class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Context,
                                                          private val sourcePath: String?,
@@ -11,6 +12,17 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
                                                                  EditImageActivity::class.java
                                                          )
 ) {
+    private var sourceUri: Uri? = null
+
+    constructor(context: Context,
+                sourceUri: Uri,
+                outputPath: String?,
+                intent: Intent = Intent(
+                        context,
+                        EditImageActivity::class.java
+                )) : this(context, null, outputPath, intent) {
+        this.sourceUri = sourceUri
+    }
 
     fun withAddText(): ImageEditorIntentBuilder {
         intent.putExtra(ADD_TEXT_FEATURE, true)
@@ -62,8 +74,15 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         return this
     }
 
+    fun withSourceUri(sourceUri: Uri): ImageEditorIntentBuilder {
+        intent.putExtra(SOURCE_URI, sourceUri)
+        intent.removeExtra(SOURCE_PATH)
+        return this
+    }
+
     fun withSourcePath(sourcePath: String): ImageEditorIntentBuilder {
         intent.putExtra(SOURCE_PATH, sourcePath)
+        intent.removeExtra(SOURCE_URI)
         return this
     }
 
@@ -85,10 +104,14 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
     @Throws(Exception::class)
     fun build(): Intent {
 
-        if (sourcePath.isNullOrBlank()) {
-            throw Exception("Output image path required. Use withOutputPath(path) to provide the output image path.")
-        } else {
+        if (sourcePath.isNullOrBlank() && sourceUri == null) {
+            throw Exception("Source image required. Use withSourcePath(path) or withSourceUri(uri) to provide the source.")
+        } else if (!sourcePath.isNullOrBlank() && sourceUri != null) {
+            throw Exception("Multiple source images specified. Use either withSourcePath(path) or withSourceUri(uri) to provide the source.")
+        } else if (!sourcePath.isNullOrBlank()) {
             intent.putExtra(SOURCE_PATH, sourcePath)
+        } else {
+            intent.putExtra(SOURCE_URI, sourceUri)
         }
 
         if (outputPath.isNullOrBlank()) {
@@ -111,6 +134,7 @@ class ImageEditorIntentBuilder @JvmOverloads constructor(private val context: Co
         const val BEAUTY_FEATURE = "beauty_feature"
         const val STICKER_FEATURE = "sticker_feature"
 
+        const val SOURCE_URI = "source_uri"
         const val SOURCE_PATH = "source_path"
         const val OUTPUT_PATH = "output_path"
         const val FORCE_PORTRAIT = "force_portrait"


### PR DESCRIPTION
There are three scenarios that are useful to know:
1. The user clicked done after making modifications to the photo
1. The user clicked done but did not make any changes
1. The user clicked back

Currently it is not possible to differentiate between 2 and 3. This pull request returns RESULT_CANCELED when the back button is pressed so differentiation is possible