### PR TITLE
generatorBit() add Exception handling

### DIFF
--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/fragment/paint/PaintFragment.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/fragment/paint/PaintFragment.java
@@ -157,7 +157,9 @@ public class PaintFragment extends BaseEditFragment implements View.OnClickListe
         activity.mainImage.setImageBitmap(activity.getMainBit());
         activity.bannerFlipper.showNext();
 
+        isEraser = false;
         customPaintView.setVisibility(View.VISIBLE);
+        customPaintView.setEraser(isEraser);
     }
 
     private void toggleButtons() {

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/fragment/paint/PaintFragment.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/fragment/paint/PaintFragment.java
@@ -157,9 +157,7 @@ public class PaintFragment extends BaseEditFragment implements View.OnClickListe
         activity.mainImage.setImageBitmap(activity.getMainBit());
         activity.bannerFlipper.showNext();
 
-        isEraser = false;
         customPaintView.setVisibility(View.VISIBLE);
-        customPaintView.setEraser(isEraser);
     }
 
     private void toggleButtons() {

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/view/CustomPaintView.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/view/CustomPaintView.java
@@ -57,8 +57,25 @@ public class CustomPaintView extends View {
     }
 
     private void generatorBit() {
-        mDrawBit = Bitmap.createBitmap(getMeasuredWidth(), getMeasuredHeight(), Bitmap.Config.ARGB_8888);
-        mPaintCanvas = new Canvas(mDrawBit);
+        int measuredWidth = getMeasuredWidth();
+        int measuredHeight = getMeasuredHeight();
+
+        if (measuredHeight <= 0 || measuredWidth <= 0) {
+            measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED);
+            measuredWidth = getMeasuredWidth();
+            measuredHeight = getMeasuredHeight();
+
+            if (measuredWidth > 0 && measuredHeight > 0) {
+                mDrawBit = Bitmap.createBitmap(measuredWidth, measuredHeight, Bitmap.Config.ARGB_8888);
+            }
+
+        } else {
+            mDrawBit = Bitmap.createBitmap(measuredWidth, measuredHeight, Bitmap.Config.ARGB_8888);
+        }
+
+        if (mDrawBit != null) {
+            mPaintCanvas = new Canvas(mDrawBit);
+        }
     }
 
     private void init(Context context) {


### PR DESCRIPTION
hi i faced exception because getMeasuredWidth() return 0
so i add some code to handle this exception 

this is crash log i faced

```
Fatal Exception: java.lang.IllegalArgumentException: width and height must be > 0
       at android.graphics.Bitmap.createBitmap(Bitmap.java:1102)
       at android.graphics.Bitmap.createBitmap(Bitmap.java:1069)
       at android.graphics.Bitmap.createBitmap(Bitmap.java:1019)
       at android.graphics.Bitmap.createBitmap(Bitmap.java:980)
       at iamutkarshtiwari.github.io.ananas.editimage.view.CustomPaintView.generatorBit(CustomPaintView.java:60)
       at iamutkarshtiwari.github.io.ananas.editimage.view.CustomPaintView.reset(CustomPaintView.java:158)
       at iamutkarshtiwari.github.io.ananas.editimage.fragment.paint.PaintFragment.backToMain(PaintFragment.java:157)
       at iamutkarshtiwari.github.io.ananas.editimage.fragment.paint.PaintFragment.onClick(PaintFragment.java:116)
       at android.view.View.performClick(View.java:7792)
       at android.view.View.performClickInternal(View.java:7769)
       at android.view.View.access$3800(View.java:910)
       at android.view.View$PerformClick.run(View.java:30213)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8663)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:567)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```